### PR TITLE
Remove manual NODENV_ROOT fallback

### DIFF
--- a/bin/nodenv-migrate
+++ b/bin/nodenv-migrate
@@ -13,10 +13,6 @@ if [ "$1" = "--complete" ]; then
   exec nodenv-versions --bare
 fi
 
-if [ -z "$NODENV_ROOT" ]; then
-  NODENV_ROOT="${HOME}/.nodenv"
-fi
-
 usage() {
   # We can remove the sed fallback once nodenv 0.2.0 is widely available.
   nodenv-help migrate 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"


### PR DESCRIPTION
`$NODENV_ROOT` is now guaranteed to exist in the context of a plugin. There is no need for us to handle the empty/unset case or provide a fallback.