### PR TITLE
Simplify help/usage error output

### DIFF
--- a/bin/nodenv-migrate
+++ b/bin/nodenv-migrate
@@ -32,15 +32,8 @@ dst="$2"
 [ -n "$src" ] || nodenv-help --usage migrate | abort
 [ -n "$dst" ] || nodenv-help --usage migrate | abort
 
-nodenv-prefix "$src" 1>/dev/null 2>&1 || {
-  echo "nodenv: not an installed version: $src" 1>&2
-  nodenv-help --usage migrate | abort
-}
-
-nodenv-prefix "$dst" 1>/dev/null 2>&1 || {
-  echo "nodenv: not an installed version: $dst" 1>&2
-  nodenv-help --usage migrate | abort
-}
+nodenv-prefix "$src" 1>/dev/null || nodenv-help --usage migrate | abort
+nodenv-prefix "$dst" 1>/dev/null || nodenv-help --usage migrate | abort
 
 if [ -z "$TMPDIR" ]; then
   TMP="/tmp"

--- a/bin/nodenv-migrate
+++ b/bin/nodenv-migrate
@@ -13,10 +13,9 @@ if [ "$1" = "--complete" ]; then
   exec nodenv-versions --bare
 fi
 
-usage() {
-  # We can remove the sed fallback once nodenv 0.2.0 is widely available.
-  nodenv-help migrate 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"
-  [ -z "$1" ] || exit "$1"
+abort() {
+  cat - >&2
+  exit 1
 }
 
 migration_failed() {
@@ -30,17 +29,17 @@ migration_failed() {
 
 src="$1"
 dst="$2"
-[ -n "$src" ] || usage 1
-[ -n "$dst" ] || usage 1
+[ -n "$src" ] || nodenv-help --usage migrate | abort
+[ -n "$dst" ] || nodenv-help --usage migrate | abort
 
 nodenv-prefix "$src" 1>/dev/null 2>&1 || {
   echo "nodenv: not an installed version: $src" 1>&2
-  usage 1
+  nodenv-help --usage migrate | abort
 }
 
 nodenv-prefix "$dst" 1>/dev/null 2>&1 || {
   echo "nodenv: not an installed version: $dst" 1>&2
-  usage 1
+  nodenv-help --usage migrate | abort
 }
 
 if [ -z "$TMPDIR" ]; then

--- a/bin/nodenv-migrate
+++ b/bin/nodenv-migrate
@@ -29,11 +29,12 @@ migration_failed() {
 
 src="$1"
 dst="$2"
-[ -n "$src" ] || nodenv-help --usage migrate | abort
-[ -n "$dst" ] || nodenv-help --usage migrate | abort
 
-nodenv-prefix "$src" 1>/dev/null || nodenv-help --usage migrate | abort
-nodenv-prefix "$dst" 1>/dev/null || nodenv-help --usage migrate | abort
+for v in "$src" "$dst"; do
+  if [ -z "$v" ] || ! nodenv-prefix "$v" 1>/dev/null; then
+    nodenv-help --usage migrate | abort
+  fi
+done
 
 if [ -z "$TMPDIR" ]; then
   TMP="/tmp"


### PR DESCRIPTION
- Refactor usage function to abort …

    nodenv has always had nodenv-help. There is no need for the sed fallback. Also, the --usage flag is necessary to only emit usage help (vs all summary help)

- Don't re-implement nodenv-prefix's error message …

    nodenv-prefix already emits the appropriate "version not installed" error message to STDERR if it doesn't exist. So let's just mute STDOUT while leaving STDERR untouched. This way we only need to append the usage output after nodenv-prefix's error message